### PR TITLE
Expose problem statistics

### DIFF
--- a/odtlearn/tests/test_solvers.py
+++ b/odtlearn/tests/test_solvers.py
@@ -1,10 +1,10 @@
 import pytest
 
+from odtlearn import ODTL
 from odtlearn.utils.solver import Solver
 
 
 def test_callback_action(skip_solver):
-
     if skip_solver:
         pytest.skip(reason="Testing on github actions")
 
@@ -62,3 +62,26 @@ def test_set_objective(skip_solver):
 
     with pytest.raises(ValueError, match="Invalid objective type: SDFSDF."):
         cbc_solver.set_objective(obj_expression, "SDFSDF")
+
+
+def test_properties(skip_solver):
+    if skip_solver:
+        pytest.skip(reason="Testing on github actions")
+
+    cbc_solver = Solver(solver_name="cbc", verbose=False)
+    # simple problem to init and solve
+    p = [10, 13, 18, 31, 7, 15]
+    w = [11, 15, 20, 35, 10, 33]
+    c, idx = 47, range(len(w))
+    x = cbc_solver.add_vars(idx, vtype=ODTL.BINARY)
+    cbc_solver.set_objective(cbc_solver.quicksum(p[i] * x[i] for i in idx), ODTL.MAX)
+    cbc_solver.add_constr(cbc_solver.quicksum(w[i] * x[i] for i in idx) <= c)
+    cbc_solver.optimize(None, None, cbc_solver, False, None)
+
+    # check that we are able to direct access the properties from the solver class
+    assert cbc_solver.optim_gap == 0.0
+    assert cbc_solver.num_constraints == 1
+    assert cbc_solver.num_decision_vars == 6
+    assert cbc_solver.num_integer_vars == 6
+    assert cbc_solver.num_non_zero == 6
+    assert cbc_solver.num_solutions == 1

--- a/odtlearn/utils/solver.py
+++ b/odtlearn/utils/solver.py
@@ -151,15 +151,35 @@ class Solver:
         prepped = self.prep_indices(*indices)
         if len(prepped) > 1:
             for element in product(*prepped):
-                name_element_dict[element] = f"{name}[{element}]"
+                name_element_dict[element] = (
+                    f"{name}_{element}".replace("[", "_")
+                    .replace("]", "_")
+                    .replace(" ", "_")
+                )
                 var_dict[element] = self.model.add_var(
-                    lb=lb, ub=ub, obj=obj, var_type=vtype, name=f"{name}[{element}]"
+                    lb=lb,
+                    ub=ub,
+                    obj=obj,
+                    var_type=vtype,
+                    name=f"{name}_{element}".replace("[", "_")
+                    .replace("]", "_")
+                    .replace(" ", "_"),
                 )
         else:
             for element in prepped[0]:
-                name_element_dict[element] = f"{name}[{element}]"
+                name_element_dict[element] = (
+                    f"{name}_{element}".replace("[", "_")
+                    .replace("]", "_")
+                    .replace(" ", "_")
+                )
                 var_dict[element] = self.model.add_var(
-                    lb=lb, ub=ub, obj=obj, var_type=vtype, name=f"{name}[{element}]"
+                    lb=lb,
+                    ub=ub,
+                    obj=obj,
+                    var_type=vtype,
+                    name=f"{name}_{element}".replace("[", "_")
+                    .replace("]", "_")
+                    .replace(" ", "_"),
                 )
         self.var_name_dict[name] = name_element_dict
         return var_dict
@@ -287,3 +307,31 @@ class Solver:
         except AttributeError:
             self.model._data = {}
         self.model._data[key] = value
+
+    @property
+    def optim_gap(self):
+        return self.model.gap
+
+    @property
+    def num_decision_vars(self):
+        return self.model.num_cols
+
+    @property
+    def num_integer_vars(self):
+        return self.model.num_int
+
+    @property
+    def num_non_zero(self):
+        return self.model.num_nz
+
+    @property
+    def num_solutions(self):
+        return self.model.num_solutions
+
+    @property
+    def num_constraints(self):
+        return self.model.num_rows
+
+    @property
+    def search_progress_log(self):
+        return self.model.search_progress_log


### PR DESCRIPTION
Make optimization statistics available as class properties. We are somewhat constrained by the properties made available by the CBC and Gurobi C interface but we are able to support the following statistics:
* optimality gap
* number of decision variables
* number of integer decision variables
* number of non-zeros in constraint matrix
* number of solutions
* search progress log
I've implemented some basic tests to ensure that these values are available as properties after solving a toy 0/1 knapsack problem.