### PR TITLE
Raise error if CBC used with Robust or Benders

### DIFF
--- a/odtlearn/flow_oct.py
+++ b/odtlearn/flow_oct.py
@@ -173,8 +173,24 @@ class BendersOCT(FlowOCTSingleSink):
             solver uses all available threads
         verbose : bool, default = False
             Flag for logging solver outputs.
-        """
 
+        Notes
+        -----
+            BendersOCT cannot be used with the CBC solver because the LP solver used in
+            the presolving step removes all tree structure variables from
+            the problem formulation.Currently, the CBC C interface does not properly
+            pass parameters to the LP solver to disable presolving as described
+            in this Github issue <https://github.com/coin-or/Cbc/issues/512>.
+            Until this issue with the CBC C interface is fixed, BendersOCT
+            will raise a `NotImplementedError` if called with `solver="cbc"`
+        """
+        if solver.lower() == "cbc":
+            raise NotImplementedError(
+                "Cannot use CBC for optimal decision trees that use lazy"
+                "constraint callbacks. "
+                "For more details see the BendersOCT documentation:"
+                "https://d3m-research-group.github.io/odtlearn/autoapi/odtlearn/flow_oct/index.html#odtlearn.flow_oct.BendersOCT"  # noqa: E501
+            )
         super().__init__(
             solver,
             _lambda,
@@ -225,7 +241,6 @@ class BendersOCT(FlowOCTSingleSink):
         self._solver.set_objective(obj, ODTL.MAXIMIZE)
 
     def fit(self, X, y):
-
         # extract column labels, unique classes and store X as a DataFrame
         self._extract_metadata(X, y)
 

--- a/odtlearn/tests/test_Flow_Benders_OCT.py
+++ b/odtlearn/tests/test_Flow_Benders_OCT.py
@@ -395,16 +395,3 @@ def test_wrong_objective_FlowOCT(synthetic_data_1):
             obj_mode="sdafasdf",
         )
         stcl.fit(X, y)
-
-    with pytest.raises(
-        AssertionError,
-        match="Wrong objective mode. obj_mode should be one of acc or balance.",
-    ):
-        bstcl = BendersOCT(
-            solver="gurobi",
-            depth=1,
-            time_limit=100,
-            num_threads=None,
-            obj_mode="aaa",
-        )
-        bstcl.fit(X, y)

--- a/odtlearn/tests/test_Flow_Benders_OCT.py
+++ b/odtlearn/tests/test_Flow_Benders_OCT.py
@@ -250,37 +250,9 @@ def test_FlowOCT_classifier():
             "cbc",
         ),
         (
-            0,
-            0,
-            True,
-            np.array([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
-            "cbc",
-        ),
-        (
-            1,
-            0,
-            True,
-            np.array([0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 0, 0]),
-            "cbc",
-        ),
-        (
-            2,
-            0,
-            True,
-            np.array([0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 0, 1, 1]),
-            "cbc",
-        ),
-        (
             2,
             0.51,
             False,
-            np.array([0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1]),
-            "cbc",
-        ),
-        (
-            2,
-            0.51,
-            True,
             np.array([0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1]),
             "cbc",
         ),
@@ -359,18 +331,6 @@ def test_FlowOCT_same_predictions(
             np.array([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1]),
             "cbc",
         ),
-        (
-            True,
-            "acc",
-            np.array([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
-            "cbc",
-        ),
-        (
-            True,
-            "balance",
-            np.array([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1]),
-            "cbc",
-        ),
     ],
 )
 def test_FlowOCT_obj_mode(
@@ -441,7 +401,7 @@ def test_wrong_objective_FlowOCT(synthetic_data_1):
         match="Wrong objective mode. obj_mode should be one of acc or balance.",
     ):
         bstcl = BendersOCT(
-            solver="cbc",
+            solver="gurobi",
             depth=1,
             time_limit=100,
             num_threads=None,

--- a/odtlearn/tests/test_RobustOCT.py
+++ b/odtlearn/tests/test_RobustOCT.py
@@ -70,9 +70,11 @@ def synthetic_costs_1():
     return costs
 
 
-def test_RobustOCT_X_noninteger_error():
+def test_RobustOCT_X_noninteger_error(skip_solver):
     """Test whether X is integer-valued"""
-    clf = RobustOCT(solver="cbc", depth=1, time_limit=20)
+    if skip_solver:
+        pytest.skip(reason="Testing on github actions")
+    clf = RobustOCT(solver="gurobi", depth=1, time_limit=20)
 
     with pytest.raises(
         ValueError,
@@ -85,9 +87,11 @@ def test_RobustOCT_X_noninteger_error():
         clf.fit(data, y)
 
 
-def test_RobustOCT_cost_shape_error():
+def test_RobustOCT_cost_shape_error(skip_solver):
     """Test whether X and cost have the same size and columns"""
-    clf = RobustOCT(solver="cbc", depth=1, time_limit=20)
+    if skip_solver:
+        pytest.skip(reason="Testing on github actions")
+    clf = RobustOCT(solver="gurobi", depth=1, time_limit=20)
     data = pd.DataFrame(
         {"x1": [1, 2, 2, 2, 3], "x2": [1, 2, 1, 0, 1], "y": [1, 1, -1, -1, -1]},
         index=["A", "B", "C", "D", "E"],
@@ -147,10 +151,12 @@ def test_RobustOCT_cost_shape_error():
         clf.fit(data, y, costs=costs, budget=5)
 
 
-def test_RobustOCT_prediction_shape_error():
+def test_RobustOCT_prediction_shape_error(skip_solver):
     """Test whether X and cost have the same size and columns"""
+    if skip_solver:
+        pytest.skip(reason="Testing on github actions")
     # Run some quick model that finishes in 1 second
-    clf = RobustOCT(solver="cbc", depth=1, time_limit=20)
+    clf = RobustOCT(solver="gurobi", depth=1, time_limit=20)
     train = pd.DataFrame(
         {"x1": [1, 2, 2, 2, 3], "x2": [1, 2, 1, 0, 1], "y": [1, 1, -1, -1, -1]},
         index=["A", "B", "C", "D", "E"],
@@ -209,7 +215,7 @@ def test_RobustOCT_prediction_shape_error():
             index=["F", "G", "H", "I", "J"],
         )
         train_nodf = np.transpose([[1, 2, 2, 2, 3], [1, 2, 1, 0, 1]])
-        clf = RobustOCT(solver="cbc", depth=1, time_limit=20)
+        clf = RobustOCT(solver="gurobi", depth=1, time_limit=20)
         clf.fit(train_nodf, y)
         clf.predict(test)
 
@@ -217,7 +223,7 @@ def test_RobustOCT_prediction_shape_error():
 def test_RobustOCT_with_uncertainty_success(skip_solver):
     if skip_solver:
         pytest.skip(reason="Testing on github actions")
-    clf = RobustOCT(solver="cbc", depth=1, time_limit=20)
+    clf = RobustOCT(solver="gurobi", depth=1, time_limit=20)
     train = pd.DataFrame(
         {"x1": [1, 2, 2, 2, 3], "x2": [1, 2, 1, 0, 1], "y": [1, 1, -1, -1, -1]},
         index=["A", "B", "C", "D", "E"],
@@ -240,7 +246,7 @@ def test_RobustOCT_with_uncertainty_success(skip_solver):
 def test_RobustOCT_no_uncertainty_success(skip_solver):
     if skip_solver:
         pytest.skip(reason="Testing on github actions")
-    clf = RobustOCT(solver="cbc", depth=1, time_limit=20)
+    clf = RobustOCT(solver="gurobi", depth=1, time_limit=20)
     train = pd.DataFrame(
         {"x1": [1, 2, 2, 2, 3], "x2": [1, 2, 1, 0, 1], "y": [1, 1, -1, -1, -1]},
         index=["A", "B", "C", "D", "E"],
@@ -275,9 +281,6 @@ def test_RobustOCT_no_uncertainty_success(skip_solver):
             np.array([0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 0, 1, 1]),
             "gurobi",
         ),
-        (0, np.array([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]), "cbc"),
-        (1, np.array([0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 0, 0]), "cbc"),
-        (2, np.array([0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 0, 1, 1]), "cbc"),
     ],
 )
 def test_RobustOCT_correctness(synthetic_data_1, d, expected_pred, solver, skip_solver):
@@ -321,30 +324,6 @@ def test_RobustOCT_correctness(synthetic_data_1, d, expected_pred, solver, skip_
             np.array([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1]),
             "gurobi",
         ),
-        (
-            0,
-            2,
-            np.array([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
-            "cbc",
-        ),
-        (
-            1,
-            2,
-            np.array([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1]),
-            "cbc",
-        ),
-        (
-            2,
-            2,
-            np.array([0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 0, 1, 1]),
-            "cbc",
-        ),  # slow
-        (
-            2,
-            5,
-            np.array([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1]),
-            "cbc",
-        ),  # slow
     ],
 )
 def test_RobustOCT_uncertainty_correctness(
@@ -376,10 +355,12 @@ def test_RobustOCT_uncertainty_correctness(
 
 
 # test that tree is fitted before trying to fit, predict, print, or plot
-def test_check_fit(synthetic_data_1):
+def test_check_fit(synthetic_data_1, skip_solver):
+    if skip_solver:
+        pytest.skip(reason="Testing on github actions")
     X, y = synthetic_data_1
     rcl = RobustOCT(
-        solver="cbc",
+        solver="gurobi",
         depth=1,
         time_limit=100,
     )
@@ -417,7 +398,7 @@ def test_RobustOCT_visualize_tree(synthetic_data_1, synthetic_costs_1, skip_solv
     X, y = synthetic_data_1
     costs = synthetic_costs_1
     robust_classifier = RobustOCT(
-        solver="cbc",
+        solver="gurobi",
         depth=1,
         time_limit=100,
     )


### PR DESCRIPTION
There is an issue with the Cbc C api passing parameters to the LP solver that is handling the presolve behavior (https://github.com/coin-or/Cbc/issues/512). This means that we don't have a guaranteed way to prevent the lp solver from removing all of our tree structure variables during presolve. Until this issue is resolved, we will raise a `NotImplementedError` if a user tries to initialize either `RobustOCT` or `BendersOCT` with `solver="cbc"`.

The error messages point users to the documentation page for each class where we have added a note that explains why we do not support using CBC for classes with lazy constraint generation.
