### PR TITLE
Add PyPI Publishing Workflow

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -2,7 +2,6 @@ name: Publish to PyPI
 
 on:
   workflow_dispatch:
-  
   release:
     types: [published]
 
@@ -57,10 +56,7 @@ jobs:
           if version in releases:
             raise SystemExit(f"Version {version} already exists on PyPI.")
           EOF
-      - name: Publish to TestPyPI
+
+      - name: Publish to PyPI
+        if: github.event_name == 'release'
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          repository-url: https://test.pypi.org/legacy/
-    
-    # - name: Publish to PyPI
-    #   uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -1,0 +1,66 @@
+name: Publish to PyPI
+
+on:
+  workflow_dispatch:
+  
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install build tools
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install build
+
+      - name: Build package
+        run: python -m build
+
+      - name: Check distributions
+        run: |
+          python -m pip install twine
+          twine check dist/*
+
+      - name: Verify version is not already on PyPI
+        run: |
+          python - <<'EOF'
+          import tomllib
+          import urllib.request
+          import json
+          import sys
+
+          with open("pyproject.toml", "rb") as f:
+            version = tomllib.load(f)["project"]["version"]
+
+          url = "https://pypi.org/pypi/odtlearn/json"
+
+          try:
+            releases = json.load(urllib.request.urlopen(url))["releases"]
+          except Exception:
+            sys.exit(0)
+
+          if version in releases:
+            raise SystemExit(f"Version {version} already exists on PyPI.")
+          EOF
+      - name: Publish to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+    
+    # - name: Publish to PyPI
+    #   uses: pypa/gh-action-pypi-publish@release/v1

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ A package for tree-based statistical estimation and inference using optimal deci
 
 ![Test badge](https://github.com/D3M-Research-Group/odtlearn/actions/workflows/ci.yml/badge.svg)
 ![Documentation badge](https://github.com/D3M-Research-Group/odtlearn/actions/workflows/sphinx.yml/badge.svg)
+![Publish to PyPI](https://github.com/D3M-Research-Group/odtlearn/actions/workflows/actions/workflows/pypi.yml/badge.svg)
+[![PyPI version](https://badge.fury.io/py/odtlearn.svg)](https://badge.fury.io/py/odtlearn)
 ![License badge](https://img.shields.io/github/license/D3M-Research-Group/odtlearn)
 
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,11 @@
 <p align="center">
-<img src="./img/ODTlearn-color.png" alt="ODTlearn Logo" width="500"/>
+<img src="https://raw.githubusercontent.com/D3M-Research-Group/odtlearn/main/img/ODTlearn-color.png" alt="ODTlearn Logo" width="500"/>
 </p>
 
 A package for tree-based statistical estimation and inference using optimal decision trees. ODTlearn provides implementations of StrongTrees [1], FairTrees [2], RobustTrees [3,4] for classification, and Prescriptive Trees [5] for prescription.
 
 ![Test badge](https://github.com/D3M-Research-Group/odtlearn/actions/workflows/ci.yml/badge.svg)
 ![Documentation badge](https://github.com/D3M-Research-Group/odtlearn/actions/workflows/sphinx.yml/badge.svg)
-![Publish to PyPI](https://github.com/D3M-Research-Group/odtlearn/actions/workflows/actions/workflows/pypi.yml/badge.svg)
 [![PyPI version](https://badge.fury.io/py/odtlearn.svg)](https://badge.fury.io/py/odtlearn)
 ![License badge](https://img.shields.io/github/license/D3M-Research-Group/odtlearn)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,8 +3,8 @@ requires = ["setuptools>=45", "setuptools_scm[toml]>=6.2", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "odtlearn"
-version = "1.1.0"
+name = "odtlearn-publish-test"
+version = "0.0.1"
 description = "A package for tree-based statistical estimation and inference using optimal decision trees."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,8 +3,8 @@ requires = ["setuptools>=45", "setuptools_scm[toml]>=6.2", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "odtlearn-publish-test"
-version = "0.0.1"
+name = "odtlearn"
+version = "1.1.0"
 description = "A package for tree-based statistical estimation and inference using optimal decision trees."
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
Automate PyPI publishing when a Github Release is made in order to maintain consistency between Github releases and PyPI.